### PR TITLE
fix small bug in json parser

### DIFF
--- a/src/schemas/parseJsonSchema.js
+++ b/src/schemas/parseJsonSchema.js
@@ -44,7 +44,7 @@ async function parseJsonSchema(schemaFile, debug = false) {
     });
 
     if (debug === 'true') {
-        const parsed = Json.parse(schemaFile);
+        const parsed = JSON.parse(schemaFile);
         console.log(parsed);
     }
 


### PR DESCRIPTION
There is a small bug here:
- https://github.com/MaterializeInc/datagen/blob/main/src/schemas/parseJsonSchema.js#L47

`Json` -> `JSON`