### PR TITLE
Add data size option to json schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ In some cases, you might need to generate a large amount of data. In that case, 
     {
         "_meta": {
             "topic": "mz_datagen_benchmark",
-            "benchmark": true
+            "benchmark": 1048576 // The size of the record in bytes
         },
         "id": "datatype.uuid"
     }
 ]
 ```
 
-The `benchmark: true` option will generate a 1MB record. So if you have to generate 1GB of data, you run the command with the following options:
+The `benchmark: 1048576` option will generate a 1MB record. So if you have to generate 1GB of data, you run the command with the following options:
 
 ```bash
 datagen -s ./tests/datasize.json -sf json -f json -n 1000

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   -n, --number <char>          Number of records to generate (default: "10")
   -d, --debug <char>            (choices: "true", "false", default: "false")
   -dr, --dry-run <char>        Dry run (no data will be produced (choices: "true", "false", default: "false")
+  -rs, --record-size <char>    Record size in bytes, eg. 1048576 for 1MB
   -h, --help                   display help for command
 ```
 
@@ -90,26 +91,16 @@ Each object represents a record that will be generated. The `_meta` key is used 
 
 You can find the documentation for Faker.js [here](https://fakerjs.dev/api/)
 
-#### JSON Schema Benchmark Option
+### Record Size Option
 
-In some cases, you might need to generate a large amount of data. In that case, you can use the `benchmark` option:
+In some cases, you might need to generate a large amount of data. In that case, you can use the `--record-size` option to generate a record of a specific size.
 
-```json
-[
-    {
-        "_meta": {
-            "topic": "mz_datagen_benchmark",
-            "benchmark": 1048576 // The size of the record in bytes
-        },
-        "id": "datatype.uuid"
-    }
-]
-```
-
-The `benchmark: 1048576` option will generate a 1MB record. So if you have to generate 1GB of data, you run the command with the following options:
+The `--record-size 1048576` option will generate a 1MB record. So if you have to generate 1GB of data, you run the command with the following options:
 
 ```bash
-datagen -s ./tests/datasize.json -sf json -f json -n 1000
+datagen -s ./tests/datasize.json -sf json -f json -n 1000 --record-size 1048576
 ```
+
+This will add a `recordSizePayload` key to the record with the specified size and will send the record to Kafka.
 
 > Note: The 'Max Message Size' of your Kafka cluster needs to be set to a higher value than 1MB for this to work.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,27 @@ The schema needs to be an array of objects, as that way we can produce relationa
 Each object represents a record that will be generated. The `_meta` key is used to define the topic that the record will be sent to.
 
 You can find the documentation for Faker.js [here](https://fakerjs.dev/api/)
+
+#### JSON Schema Benchmark Option
+
+In some cases, you might need to generate a large amount of data. In that case, you can use the `benchmark` option:
+
+```json
+[
+    {
+        "_meta": {
+            "topic": "mz_datagen_benchmark",
+            "benchmark": true
+        },
+        "id": "datatype.uuid"
+    }
+]
+```
+
+The `benchmark: true` option will generate a 1MB record. So if you have to generate 1GB of data, you run the command with the following options:
+
+```bash
+datagen -s ./tests/datasize.json -sf json -f json -n 1000
+```
+
+> Note: The 'Max Message Size' of your Kafka cluster needs to be set to a higher value than 1MB for this to work.

--- a/datagen.js
+++ b/datagen.js
@@ -50,7 +50,8 @@ program
         new Option('-dr, --dry-run <char>', 'Dry run (no data will be produced')
             .choices(['true', 'false'])
             .default('false')
-    );
+    )
+    .option('-rs, --record-size <int>', 'Record size in bytes, eg. 1048576 for 1MB', parseInt);
 
 program.parse();
 
@@ -66,6 +67,7 @@ if (!fs.existsSync(options.schema)) {
 }
 
 global.debug = options.debug;
+global.recordSize = options.recordSize;
 
 if (debug === 'true') {
     console.log(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "cli-meow-help": "^3.1.0",
                 "cli-welcome": "^2.2.2",
                 "commander": "^9.4.1",
+                "crypto": "^1.0.1",
                 "dotenv": "^16.0.2",
                 "inquirer": "^8.1.0",
                 "kafkajs": "^2.2.3",
@@ -1970,6 +1971,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/crypto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+            "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+            "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -6282,6 +6289,11 @@
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
+        },
+        "crypto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+            "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
         },
         "debug": {
             "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "cli-meow-help": "^3.1.0",
         "cli-welcome": "^2.2.2",
         "commander": "^9.4.1",
+        "crypto": "^1.0.1",
         "dotenv": "^16.0.2",
         "inquirer": "^8.1.0",
         "kafkajs": "^2.2.3",

--- a/src/jsonDataGenerator.js
+++ b/src/jsonDataGenerator.js
@@ -1,8 +1,10 @@
 const alert = require('cli-alerts');
+const crypto = require('crypto');
 const fs = require('fs');
 const { faker } = require('@faker-js/faker');
 const createTopic = require('./kafka/createTopic');
 const producer = require('./kafka/producer');
+
 const {
     prepareAvroData,
     getAvroTopicName
@@ -164,6 +166,12 @@ module.exports = async ({ format, schema, number, schemaFormat, dryRun = false, 
                         break;
                     default:
                         break;
+                }
+
+                if (recordSize) {
+                    recordSize = (recordSize) / 2;
+                    let payload = crypto.randomBytes(recordSize).toString('hex');
+                    record.recordSizePayload = payload;
                 }
 
                 let avro_schema;

--- a/src/schemas/parseJsonSchema.js
+++ b/src/schemas/parseJsonSchema.js
@@ -1,19 +1,12 @@
 const alert = require('cli-alerts');
 const fs = require('fs');
 const { faker } = require('@faker-js/faker');
-const crypto = require('crypto');
 
 async function prepareJsonData(schema, uuid = null) {
     // Iterate over the object and replace the values with faker data
     const record = {};
     for (const [key, value] of Object.entries(schema)) {
         if (key === '_meta') {
-            if (schema._meta && schema._meta.benchmark) {
-                const size = (schema._meta.benchmark) / 2;
-                let payload = crypto.randomBytes(size).toString('hex');
-                record["benchmarkPayload"] = payload;
-                continue;
-            }
             continue;
         }
         if (typeof value === 'object') {

--- a/src/schemas/parseJsonSchema.js
+++ b/src/schemas/parseJsonSchema.js
@@ -1,12 +1,20 @@
 const alert = require('cli-alerts');
 const fs = require('fs');
 const { faker } = require('@faker-js/faker');
+const crypto = require('crypto');
 
 async function prepareJsonData(schema, uuid = null) {
     // Iterate over the object and replace the values with faker data
     const record = {};
     for (const [key, value] of Object.entries(schema)) {
         if (key === '_meta') {
+            if (schema._meta && schema._meta.benchmark) {
+                // ~1MB payload record size
+                const size = (1 * 1012 * 1012) / 2;
+                let payload = crypto.randomBytes(size).toString('hex');
+                record["benchmarkPayload"] = payload;
+                continue;
+            }
             continue;
         }
         if (typeof value === 'object') {

--- a/src/schemas/parseJsonSchema.js
+++ b/src/schemas/parseJsonSchema.js
@@ -9,8 +9,7 @@ async function prepareJsonData(schema, uuid = null) {
     for (const [key, value] of Object.entries(schema)) {
         if (key === '_meta') {
             if (schema._meta && schema._meta.benchmark) {
-                // ~1MB payload record size
-                const size = (1 * 1012 * 1012) / 2;
+                const size = (schema._meta.benchmark) / 2;
                 let payload = crypto.randomBytes(size).toString('hex');
                 record["benchmarkPayload"] = payload;
                 continue;

--- a/tests/datagen.test.js
+++ b/tests/datagen.test.js
@@ -47,3 +47,17 @@ describe('Test missing schema file', () => {
         expect(output).toContain(`Schema file ${schema} does not exist!`);
     });
 });
+
+describe('Test record size', () => {
+    test('should not contain the recordSizePayload if record size is not set', () => {
+        const schema = './tests/schema.avsc';
+        const output = datagen(`-s ${schema} -sf avro -n 2`);
+        expect(output).not.toContain('recordSizePayload');
+    });
+    test('should contain the recordSizePayload if record size is set', () => {
+        const schema = './tests/schema.avsc';
+        const output = datagen(`-s ${schema} -sf avro -n 2 -rs 100`);
+        expect(output).toContain('recordSizePayload');
+    }
+    );
+});

--- a/tests/datasize.json
+++ b/tests/datasize.json
@@ -2,7 +2,7 @@
     {
         "_meta": {
             "topic": "mz_datagen_benchmark",
-            "benchmark": true
+            "benchmark": 1048576
         },
         "id": "datatype.uuid"
     }

--- a/tests/datasize.json
+++ b/tests/datasize.json
@@ -1,10 +1,9 @@
 [
     {
         "_meta": {
-            "topic": "mz_datagen_users",
-            "message_size": "1MB"
+            "topic": "mz_datagen_benchmark",
+            "benchmark": true
         },
-        "id": "1",
-        "body": "message_size"
+        "id": "datatype.uuid"
     }
 ]

--- a/tests/datasize.json
+++ b/tests/datasize.json
@@ -1,9 +1,0 @@
-[
-    {
-        "_meta": {
-            "topic": "mz_datagen_benchmark",
-            "benchmark": 1048576
-        },
-        "id": "datatype.uuid"
-    }
-]


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Adding an option to the JSON schema to allow generating 1MB records.

The `benchmark: true` option in the `_mata` field, will generate a 1MB record. So if you have to generate 1GB of data, you run the command with the following options:

## Related Tickets & Documents

Closes #4 

## Added to documentation?

- [x] 📜 readme
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
