### PR TITLE
send user specified record keys to kafka

### DIFF
--- a/src/jsonDataGenerator.js
+++ b/src/jsonDataGenerator.js
@@ -168,10 +168,15 @@ module.exports = async ({ format, schema, number, schemaFormat, dryRun = false, 
                         break;
                 }
 
-                if (table["_meta"]["key"]) {
+                let recordKey = null;
+                try {
                     recordKey = record[table["_meta"]["key"]]
-                } else {
-                    recordKey = null
+                } catch (error) {
+                    alert({
+                        type: `warn`,
+                        name: `No key specified. Using null key`,
+                        msg: `\n  ${error.message}`
+                    });
                 }
 
                 if (recordSize) {

--- a/src/jsonDataGenerator.js
+++ b/src/jsonDataGenerator.js
@@ -182,7 +182,7 @@ module.exports = async ({ format, schema, number, schemaFormat, dryRun = false, 
 
                 let avro_schema;
                 let schema_id;
-                let encodedRecord;
+                let encodedRecord = null;
                 if (format == 'avro') {
                     avro_schema = getAvroSchema(topic,record,debug);
                 }
@@ -193,14 +193,13 @@ module.exports = async ({ format, schema, number, schemaFormat, dryRun = false, 
                         name: `Dry run: Skipping record production...`,
                         msg: `\n  Topic: ${topic} \n  Record key: ${recordKey} \n  Payload: ${JSON.stringify(record)}`
                     });
-                } else if (format == 'avro') {
-                    schema_id = await registerSchema(avro_schema, registry);
-                    encodedRecord = await getAvroEncodedRecord(record,registry,schema_id);
-                    await producer(recordKey, record, encodedRecord, topic);
                 } else {
-                    encodedRecord = null
+                    if (format == 'avro') {
+                        schema_id = await registerSchema(avro_schema, registry);
+                        encodedRecord = await getAvroEncodedRecord(record,registry,schema_id);
+                    }
+                    await producer(recordKey, record, encodedRecord, topic)
                 }
-                await producer(recordKey, record, encodedRecord, topic)
             })
         );
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/src/kafka/producer.js
+++ b/src/kafka/producer.js
@@ -3,7 +3,7 @@ const kafkaConfig = require('./kafkaConfig');
 const alert = require('cli-alerts');
 const dotenv = require('dotenv');
 
-module.exports = async (record, encodedRecord = null, topic = 'test_123') => {
+module.exports = async (recordKey = null, record, encodedRecord = null, topic = 'test_123') => {
     // Produce the record to Kafka
     const kafka = kafkaConfig();
 
@@ -22,7 +22,7 @@ module.exports = async (record, encodedRecord = null, topic = 'test_123') => {
     await producer.send({
         topic: topic,
         messages: [{
-            key: record.id,
+            key: recordKey,
             value: payload
         }]
     });
@@ -30,7 +30,7 @@ module.exports = async (record, encodedRecord = null, topic = 'test_123') => {
     alert({
         type: `success`,
         name: `Record sent to Kafka topic: ${topic}`,
-        msg: `\n  ${JSON.stringify(record)}`
+        msg: `\nkey: ${recordKey}\nvalue:\n${JSON.stringify(record)}`
     });
 
     await producer.disconnect();

--- a/src/schemas/parseJsonSchema.js
+++ b/src/schemas/parseJsonSchema.js
@@ -2,7 +2,7 @@ const alert = require('cli-alerts');
 const fs = require('fs');
 const { faker } = require('@faker-js/faker');
 
-async function prepareJsonData(schema, uuid = null) {
+async function prepareJsonData(schema) {
     // Iterate over the object and replace the values with faker data
     const record = {};
     for (const [key, value] of Object.entries(schema)) {
@@ -12,23 +12,6 @@ async function prepareJsonData(schema, uuid = null) {
         if (typeof value === 'object') {
             record[key] = await prepareJsonData(value);
         } else {
-            // Check if the schema has a key property in the _meta object
-            if (schema._meta && schema._meta.key) {
-                if (key === schema._meta.key) {
-                    if (uuid) {
-                        record[key] = uuid;
-                        continue;
-                    }
-                }
-            }
-            if (schema._meta && schema._meta.foreignKey) {
-                if (key === schema._meta.foreignKey) {
-                    if (uuid) {
-                        record[key] = uuid;
-                        continue;
-                    }
-                }
-            }
             const [fakerMethod, fakerProperty] = value.split('.');
             record[key] = faker[fakerMethod][fakerProperty]();
         }

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -26,6 +26,7 @@
     {
         "_meta": {
             "topic": "mz_datagen_comments",
+            "key": "email",
             "foreignKey": "post_id"
         },
         "id": "datatype.uuid",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

As a stepping stone to supporting relational data, I fixed Kafka record keys (json schema only). Now you can specify key like so:

```json
[
    {
        "_meta": {
            "topic": "mz_datagen_comments",
            "key": "email"
        },
        "id": "datatype.uuid",
        "name": "internet.userName",
        "email": "internet.exampleEmail",
        "body": "lorem.paragraph",
        "post_id": "datatype.uuid"
    }
]
```

And the `email` will be used as the kafka record key:

```
✔  Record sent to Kafka topic: mz_datagen_comments  
key: Dorris87@example.org
value:
{"id":"a0bf7ce4-24b7-49e1-bc08-7f4d9d61a75f","name":"Coty91","email":"Dorris87@example.org","body":"Et cum cum perspiciatis inventore atque quis animi. Explicabo eos ea. Dolorem praesentium reprehenderit. Accusantium voluptates delectus nam earum minus pariatur soluta. Omnis recusandae quaerat placeat. Amet enim architecto.","post_id":"1d73e87e-dd71-4a1d-a6c7-f1f9f3c3321d"}
```

## Related Tickets & Documents

- #1 

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

