### PR TITLE
Add faker data properties

### DIFF
--- a/src/schemas/generateMegaRecord.js
+++ b/src/schemas/generateMegaRecord.js
@@ -12,8 +12,31 @@ async function generateRandomRecord(fakerRecord, generatedRecord = {}){
             generatedRecord[field] = await generateRandomRecord(fakerRecord[field])
         } else {
             try {
-                const [fakerMethod, fakerProperty] = fakerRecord[field].split('.');
-                generatedRecord[field] = faker[fakerMethod][fakerProperty]();
+                const [fakerMethod, ...property] = fakerRecord[field].split('.');
+                const fakerProperty = property.join('.');
+                console.log(fakerMethod, fakerProperty)
+                if (fakerProperty.includes('(')) {
+                    const property = fakerProperty.split('(')[0];
+                    let args = fakerProperty.split('(')[1].split(')')[0];
+
+                    if (!args.includes('{')) {
+                        args = !isNaN(args) ? Number(args) : args === 'true' ? true : args === 'false' ? false : args;
+                    } else {
+                        try {
+                            args = JSON.parse(args);
+                        } catch (error) {
+                            alert({
+                                type: `error`,
+                                name: `JSON parse error`,
+                                msg: `${error.message}\n${JSON.stringify(generatedRecord,null,2)}`
+                            });
+                        }
+                    }
+                    generatedRecord[field] = faker[fakerMethod][property](args);
+                } else {
+                    generatedRecord[field] = faker[fakerMethod][fakerProperty]();
+                }
+
             } catch (error) {
                 alert({
                     type: `error`,
@@ -27,7 +50,6 @@ async function generateRandomRecord(fakerRecord, generatedRecord = {}){
     }
     return generatedRecord;
 }
-
 
 async function generateMegaRecord(schema) {
     // goal is to return a "mega record" with structure

--- a/src/schemas/generateMegaRecord.js
+++ b/src/schemas/generateMegaRecord.js
@@ -14,7 +14,6 @@ async function generateRandomRecord(fakerRecord, generatedRecord = {}){
             try {
                 const [fakerMethod, ...property] = fakerRecord[field].split('.');
                 const fakerProperty = property.join('.');
-                console.log(fakerMethod, fakerProperty)
                 if (fakerProperty.includes('(')) {
                     const property = fakerProperty.split('(')[0];
                     let args = fakerProperty.split('(')[1].split(')')[0];

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -55,6 +55,8 @@
         "id": "datatype.uuid",
         "user_id": "datatype.uuid",
         "body": "lorem.paragraph",
-        "post_id": "datatype.uuid"
+        "post_id": "datatype.uuid",
+        "views": "datatype.number({\"min\": 100, \"max\": 1000})",
+        "status": "datatype.number(1)"
     }
 ]

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE "ecommerce"."products" (
   "id" int PRIMARY KEY,
   "name" varchar COMMENT 'internet.userName',
   "merchant_id" int NOT NULL COMMENT 'datatype.number',
-  "price" int COMMENT 'datatype.number',
+  "price" int COMMENT 'datatype.number({ "min": 1000, "max": 100000 })',
   "status" int COMMENT 'datatype.boolean',
   "created_at" datetime DEFAULT (now())
 );


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Adding an option to allow users to specify the faker properties options, eg:

```
faker.datatype.number(options: number | {
  max: number,
  min: number,
  precision: number
} = 99999): number
```

There are some edge cases like dates, where this still needs to be improved, but it should cover what's mentioned in #39 

## Related Tickets & Documents

Closes #39 

## Added to documentation?

- [ ] 📜 readme
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
