### PR TITLE
Add Iternation index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,27 @@ docker run \
   -v ${PWD}/tests/schema.json:/app/blah.json \
     datagen -s blah.json -n 1 -dr true
 ```
+
+### Generate records with sequence numbers
+
+To simulate auto incrementing primary keys, you can use the `iteration.index` variable in the schema.
+
+This is particularly useful when you want to generate a small set of records with sequence of IDs, for example 1000 records with IDs from 1 to 1000:
+
+```json
+[
+    {
+        "_meta": {
+            "topic": "mz_datagen_users"
+        },
+        "id": "iteration.index",
+        "name": "internet.userName",
+    }
+]
+```
+
+Example:
+
+```
+datagen -s tests/iterationIndex.json -dr true -f json -n 1000
+```

--- a/src/dataGenerator.js
+++ b/src/dataGenerator.js
@@ -105,6 +105,7 @@ module.exports = async ({
     let avroSchemas = {};
 
     for await (const iteration of asyncGenerator(number)) {
+        global.iterationIndex = iteration;
         megaRecord = await generateMegaRecord(schema);
 
         if (iteration == 0) {

--- a/src/schemas/generateMegaRecord.js
+++ b/src/schemas/generateMegaRecord.js
@@ -11,6 +11,10 @@ async function generateRandomRecord(fakerRecord, generatedRecord = {}){
         if (typeof fakerRecord[field] === 'object'){
             generatedRecord[field] = await generateRandomRecord(fakerRecord[field])
         } else {
+            if (fakerRecord[field] === 'iteration.index'){
+                generatedRecord[field] = iterationIndex + 1;
+                continue;
+            }
             try {
                 const [fakerMethod, ...property] = fakerRecord[field].split('.');
                 const fakerProperty = property.join('.');

--- a/tests/iterationIndex.json
+++ b/tests/iterationIndex.json
@@ -1,0 +1,16 @@
+{
+    "_meta": {
+        "topic": "air_quality",
+        "key": "id"
+    },
+    "id": "iteration.index",
+    "timestamp": "date.between('2020-01-01T00:00:00.000Z', '2030-01-01T00:00:00.000Z')",
+    "location": {
+        "latitude": "datatype.number({ \"max\": 90, \"min\": -90})",
+        "longitude": "datatype.number({ \"max\": 180, \"min\": -180})"
+    },
+    "pm25": "datatype.float({ \"min\": 10, \"max\": 90 })",
+    "pm10": "datatype.float({ \"min\": 10, \"max\": 90 })",
+    "temperature": "datatype.float({ \"min\": -10, \"max\": 120 })",
+    "humidity": "datatype.float({ \"min\": 0, \"max\": 100 })"
+}


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

To simulate auto incrementing primary keys, you can use the `iteration.index` variable in the schema.

This is particularly useful when you want to generate a small set of records with sequence of IDs, for example 1000 records with IDs from 1 to 1000:

```json
[
    {
        "_meta": {
            "topic": "mz_datagen_users"
        },
        "id": "iteration.index",
        "name": "internet.userName",
    }
]
```

Example:

```
datagen -s tests/iterationIndex.json -dr true -f json -n 1000
```

This does not work particularly well with the relational data implementation, but it is mainly intended to be used with single schemas, eg. the Storage utilization test task.


## Related Tickets & Documents

N/A

## Added to documentation?

- [x] 📜 readme
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
