### PR TITLE
Show debug output for avro schemas during dry run

### DIFF
--- a/src/dataGenerator.ts
+++ b/src/dataGenerator.ts
@@ -48,7 +48,7 @@ export default async function dataGenerator({
         payload = crypto.randomBytes(global.recordSize).toString('hex');
     }
 
-    let producer: KafkaProducer | null = null;
+    let producer: KafkaProducer | null = null; 
     if (global.dryRun !== true) {
         let outputFormat: OutputFormat;
         if (format === 'avro') {
@@ -66,6 +66,9 @@ export default async function dataGenerator({
 
         if (iteration == 0) {
             await producer?.prepare(megaRecord);
+            if (global.debug && global.dryRun && format == 'avro') {
+                let avroSchemas = await AvroFormat.getAvroSchemas(megaRecord);
+            }
         }
 
         for (const topic in megaRecord) {

--- a/src/dataGenerator.ts
+++ b/src/dataGenerator.ts
@@ -48,7 +48,7 @@ export default async function dataGenerator({
         payload = crypto.randomBytes(global.recordSize).toString('hex');
     }
 
-    let producer: KafkaProducer | null = null; 
+    let producer: KafkaProducer | null = null;
     if (global.dryRun !== true) {
         let outputFormat: OutputFormat;
         if (format === 'avro') {

--- a/src/formats/avroFormat.ts
+++ b/src/formats/avroFormat.ts
@@ -33,7 +33,7 @@ export class AvroFormat implements OutputFormat {
         this.registry = registry;
     }
     
-    private nameHook() {
+    private static nameHook() {
         let index = 0;
         return function (schema, opts) {
             switch (schema.type) {
@@ -48,7 +48,7 @@ export class AvroFormat implements OutputFormat {
     }
     
     // @ts-ignore
-    async getAvroSchemas(megaRecord: any) {
+    static async getAvroSchemas(megaRecord: any) {
         let avroSchemas = {};
         for (let topic in megaRecord) {
             // @ts-ignore
@@ -59,7 +59,7 @@ export class AvroFormat implements OutputFormat {
             if (global.debug) {
                 alert({
                     type: `success`,
-                    name: `Avro Schema:`,
+                    name: `Avro Schema for topic ${topic}:`,
                     msg: `\n ${JSON.stringify(avroSchema, null, 2)}`
                 });
             }
@@ -70,7 +70,7 @@ export class AvroFormat implements OutputFormat {
     }
 
     async register(megaRecord: any): Promise<void> {
-        const avroSchemas = await this.getAvroSchemas(megaRecord);
+        const avroSchemas = await AvroFormat.getAvroSchemas(megaRecord);
         for (const topic in avroSchemas) {
             let options = { subject: `${topic}-value` }
             let avroSchema = avroSchemas[topic]


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

We lost the ability to see output avro schema when debugging a dry run. This happened because creating an instance of the AvroFormat class requires creating a schema registry client (which shouldn't happen on dry run). However, we don't actually need to create a schema registry client in order to see the what avro schemas would be produced with `--format avro`. All that is needed is one instance of a "megaRecord". We then use the @types/avro library to generate avro schema from the record.

To bring back this functionality of debugging output avro schema for a dry run, I made the `getAvroSchemas(megaRecord)` method static and call it during dry run on the first iteration in `dataGenerator`.

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed
