### PR TITLE
Add mutual TLS authentication support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 # Kafka
+KAFKA_BROKERS=
+
+# Kafka SASL Authentication
 SASL_USERNAME=
 SASL_PASSWORD=
 SASL_MECHANISM=
-KAFKA_BROKERS=
+
+# Kafka SSL Authentication
+SSL_CA_LOCATION=
+SSL_CERT_LOCATION=
+SSL_KEY_LOCATION=
 
 # Schema Registry if producing Avro
 SCHEMA_REGISTRY_URL=

--- a/README.md
+++ b/README.md
@@ -39,11 +39,18 @@ npm link
 Create a file called `.env` with the following environment variables
 
 ```bash
-# Connect to Kafka
+# Kafka Brokers
+KAFKA_BROKERS=
+
+# For Kafka SASL Authentication:
 SASL_USERNAME=
 SASL_PASSWORD=
 SASL_MECHANISM=
-KAFKA_BROKERS=
+
+# For Kafka SSL Authentication:
+SSL_CA_LOCATION=
+SSL_CERT_LOCATION=
+SSL_KEY_LOCATION=
 
 # Connect to Schema Registry if using '--format avro'
 SCHEMA_REGISTRY_URL=

--- a/src/kafka/kafkaConfig.ts
+++ b/src/kafka/kafkaConfig.ts
@@ -1,11 +1,15 @@
 import { Kafka, KafkaConfig } from 'kafkajs';
 import { Env } from '../utils/env.js';
+import fs from 'fs';
 
 export default async function kafkaConfig() {
     const kafkaBrokers = Env.optional("KAFKA_BROKERS", "localhost:9092");
     const kafkaUser = Env.optional("SASL_USERNAME", null);
     const kafkaPassword = Env.optional("SASL_PASSWORD", null);
     const saslMechanism = Env.optional("SASL_MECHANISM", 'plain');
+    const sslCaLocation = Env.optional("SSL_CA_LOCATION", null);
+    const sslCertLocation = Env.optional("SSL_CERT_LOCATION", null);
+    const sslKeyLocation = Env.optional("SSL_KEY_LOCATION", null);
 
     if (kafkaUser && kafkaPassword) {
         const conf: KafkaConfig = {
@@ -17,6 +21,24 @@ export default async function kafkaConfig() {
                 password: kafkaPassword
             },
             ssl: true,
+            connectionTimeout: 10_000,
+            authenticationTimeout: 10_000
+        };
+        const kafka = new Kafka(conf);
+        return kafka;
+    }
+
+    if (sslCaLocation && sslCertLocation && sslKeyLocation) {
+        if (!fs.existsSync(sslCaLocation) || !fs.existsSync(sslCertLocation) || !fs.existsSync(sslKeyLocation)) {
+            throw new Error("SSL files not found");
+        }
+        const conf: KafkaConfig = {
+            brokers: [kafkaBrokers],
+            ssl: {
+                ca: [fs.readFileSync(sslCaLocation, 'utf-8')],
+                key: fs.readFileSync(sslKeyLocation, 'utf-8'),
+                cert: fs.readFileSync(sslCertLocation, 'utf-8')
+            },
             connectionTimeout: 10_000,
             authenticationTimeout: 10_000
         };


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Adding support for mutual TLS authentication.

The user needs to set the following env vars:

```
# For Kafka SSL Authentication:
SSL_CA_LOCATION=
SSL_CERT_LOCATION=
SSL_KEY_LOCATION=
```

We will have the following precedence: 

- If SASL env details are set, we will default to that
- Next in order will be TLS details
- Finally, if none are set we will default to no auth, eg. locally running Kafka

## Related Tickets & Documents

Closes #69 

## Added to documentation?

- [x] 📜 readme
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
