### PR TITLE
Switch tests to redpanda

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,6 +1,10 @@
 name: Integration Tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.txt"
+      - "examples/**"
     branches:
       - main
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -21,7 +21,7 @@ jobs:
         run: docker exec datagen datagen --version
 
       - name: Produce to Kafka from SQL Schema in JSON Format
-        run: docker exec datagen datagen -s /tests/schema2.sql -f json -n 3 --record-size 100 -d
+        run: docker exec datagen datagen -s /tests/products.sql -f json -n 3 --record-size 100 -d -p sql
 
       - name: Produce to Kafka from JSON Schema in JSON Format
         run: docker exec datagen datagen -s /tests/schema.json -f json -n 3 --record-size 100 -d
@@ -29,8 +29,8 @@ jobs:
       - name: Produce to Kafka from Avro Schema in JSON Format
         run: docker exec datagen datagen -s /tests/schema.avsc -f json -n 3 --record-size 100 -d
 
-      - name: Produce to Kafka from SQL Schema in Avro Format
-        run: docker exec datagen datagen -s /tests/schema2.sql -f avro -n 3 --record-size 100 -d -w 100
+      # - name: Produce to Kafka from SQL Schema in Avro Format
+      #   run: docker exec datagen datagen -s /tests/products.sql -f avro -n 3 --record-size 100 -d -w 100
 
       - name: Produce to Kafka from JSON Schema in Avro Format
         run: docker exec datagen datagen -s /tests/schema.json -f avro -n 3 --record-size 100 -d -w 100 -p json
@@ -38,11 +38,11 @@ jobs:
       - name: Produce to Kafka from Avro Schema in Avro Format
         run: docker exec datagen datagen -s /tests/schema.avsc -f avro -n 3 --record-size 100 -d -w 100 -p avro
 
-      - name: Clean Kafka topic
-        run: docker exec datagen datagen -s /tests/schema2.sql -f json -d --clean
+      # - name: Clean Kafka topic
+      #   run: docker exec datagen datagen -s /tests/products.sql -f json -d --clean
 
       - name: Clean Kafka topic with prefix
-        run: docker exec datagen datagen -s /tests/schema2.sql -f json -d --clean --prefix json
+        run: docker exec datagen datagen -s /tests/schema.json -f avro -d --clean --prefix json
 
       - name: Clean Kafka topic and schema registry
         run: docker exec datagen datagen -s /tests/schema.avsc -f avro -d --clean --prefix avro

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -36,16 +36,16 @@ jobs:
         run: docker exec datagen datagen -s /tests/schema.json -f avro -n 3 --record-size 100 -d -w 100 -p json
 
       - name: Produce to Kafka from Avro Schema in Avro Format
-        run: docker exec datagen datagen -s /tests/schema.avsc -f avro -n 3 --record-size 100 -d -w 100 -p sql
+        run: docker exec datagen datagen -s /tests/schema.avsc -f avro -n 3 --record-size 100 -d -w 100 -p avro
 
       - name: Clean Kafka topic
         run: docker exec datagen datagen -s /tests/schema2.sql -f json -d --clean
 
       - name: Clean Kafka topic with prefix
-        run: docker exec datagen datagen -s /tests/schema2.sql -f json -d --clean --prefix test
+        run: docker exec datagen datagen -s /tests/schema2.sql -f json -d --clean --prefix json
 
       - name: Clean Kafka topic and schema registry
-        run: docker exec datagen datagen -s /tests/schema.avsc -f avro -d --clean
+        run: docker exec datagen datagen -s /tests/schema.avsc -f avro -d --clean --prefix avro
 
       - name: Docker Compose Down
         run: docker compose down -v

--- a/datagen.ts
+++ b/datagen.ts
@@ -49,7 +49,7 @@ if (!fs.existsSync(options.schema)) {
         name: `Schema file ${options.schema} does not exist!`,
         msg: ``
     });
-    process.exit();
+    process.exit(1);
 }
 
 global.debug = options.debug;
@@ -101,7 +101,7 @@ if (!global.wait) {
             name: `Could not parse schema`,
             msg: `\n  ${error.message}`
         });
-        process.exit();
+        process.exit(1);
     }
 
     if (global.clean) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,46 +3,36 @@ version: "3.9"
 
 services:
 
-  zookeeper:
-    image: quay.io/debezium/zookeeper:1.9
-    container_name: zookeeper
+  redpanda:
+    image: docker.vectorized.io/vectorized/redpanda:v21.11.2
+    command:
+      - redpanda start
+      - --overprovisioned
+      - --smp 1
+      - --memory 1G
+      - --reserve-memory 0M
+      - --node-id 0
+      - --check=false
+      - --kafka-addr 0.0.0.0:9092
+      - --advertise-kafka-addr ${EXTERNAL_IP:-redpanda}:9092
+      - --pandaproxy-addr 0.0.0.0:8082
+      - --advertise-pandaproxy-addr ${EXTERNAL_IP:-redpanda}:8082
+      - --set redpanda.enable_transactions=true
+      - --set redpanda.enable_idempotence=true
     ports:
-     - 2181:2181
-     - 2888:2888
-     - 3888:3888
-
-  kafka:
-    image: quay.io/debezium/kafka:1.9
-    container_name: kafka
-    ports:
-     - 9092:9092
-    links:
-     - zookeeper
-    environment:
-      ZOOKEEPER_CONNECT: zookeeper:2181
-
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.0
-    container_name: schema-registry
-    ports:
+      - 9092:9092
       - 8081:8081
-    depends_on:
-      - kafka
-      - zookeeper
-    environment:
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081,http://localhost:8081
-    healthcheck: {test: curl -f localhost:8081, interval: 1s, start_period: 120s}
+      - 8082:8082
+    healthcheck: {test: curl -f localhost:9644/v1/status/ready, interval: 1s, start_period: 30s}
 
   datagen:
     build: .
     container_name: datagen
     depends_on:
-      schema-registry: {condition: service_healthy}
+      redpanda: {condition: service_healthy}
     environment:
-      SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      KAFKA_BROKERS: kafka:9092
+      SCHEMA_REGISTRY_URL: http://redpanda:8081
+      KAFKA_BROKERS: redpanda:9092
     volumes:
       - ./tests:/tests
     # Override the entrypoint to run the container and keep it running

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@materializeinc/datagen",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@materializeinc/datagen",
-            "version": "0.1.4",
+            "version": "0.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@avro/types": "^1.0.25",
@@ -82,21 +82,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-            "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+            "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.21.0",
+                "@babel/generator": "^7.21.3",
                 "@babel/helper-compilation-targets": "^7.20.7",
-                "@babel/helper-module-transforms": "^7.21.0",
+                "@babel/helper-module-transforms": "^7.21.2",
                 "@babel/helpers": "^7.21.0",
-                "@babel/parser": "^7.21.0",
+                "@babel/parser": "^7.21.3",
                 "@babel/template": "^7.20.7",
-                "@babel/traverse": "^7.21.0",
-                "@babel/types": "^7.21.0",
+                "@babel/traverse": "^7.21.3",
+                "@babel/types": "^7.21.3",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -117,22 +117,13 @@
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true
         },
-        "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/generator": {
-            "version": "7.21.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-            "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+            "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.21.0",
+                "@babel/types": "^7.21.3",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -173,30 +164,6 @@
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
             }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
         },
         "node_modules/@babel/helper-environment-visitor": {
             "version": "7.18.9",
@@ -392,6 +359,15 @@
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
             "dev": true
         },
+        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -414,9 +390,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-            "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+            "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -617,19 +593,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-            "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+            "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.21.1",
+                "@babel/generator": "^7.21.3",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.21.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.21.2",
-                "@babel/types": "^7.21.2",
+                "@babel/parser": "^7.21.3",
+                "@babel/types": "^7.21.3",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -638,9 +614,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-            "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+            "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -1173,9 +1149,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.21.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
-            "integrity": "sha512-rc9K8ZpVjNcLs8Fp0dkozd5Pt2Apk1glO4Vgz8ix1u6yFByxfqo5Yavpy65o+93TAe24jr7v+eSBtFLvOQtCRQ==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+            "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -1235,9 +1211,9 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
-            "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+            "version": "29.5.0",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+            "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -1257,9 +1233,9 @@
             "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
         },
         "node_modules/@types/node": {
-            "version": "18.14.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-            "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
+            "version": "18.15.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.7.tgz",
+            "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA=="
         },
         "node_modules/@types/prettier": {
             "version": "2.7.2",
@@ -1274,9 +1250,9 @@
             "dev": true
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.17",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-            "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.23.tgz",
+            "integrity": "sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -1725,9 +1701,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-            "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+            "version": "4.21.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
             "dev": true,
             "funding": [
                 {
@@ -1740,10 +1716,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001400",
-                "electron-to-chromium": "^1.4.251",
-                "node-releases": "^2.0.6",
-                "update-browserslist-db": "^1.0.9"
+                "caniuse-lite": "^1.0.30001449",
+                "electron-to-chromium": "^1.4.284",
+                "node-releases": "^2.0.8",
+                "update-browserslist-db": "^1.0.10"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1807,9 +1783,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001439",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-            "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+            "version": "1.0.30001469",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+            "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
             "dev": true,
             "funding": [
                 {
@@ -1857,10 +1833,16 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-            "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+            "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
             "engines": {
                 "node": ">=8"
             }
@@ -1918,6 +1900,14 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "node_modules/cli-handle-error/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/cli-handle-error/node_modules/has-flag": {
             "version": "3.0.0",
@@ -2028,6 +2018,14 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
+        "node_modules/cli-welcome/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/cli-welcome/node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2105,9 +2103,9 @@
             }
         },
         "node_modules/commander": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-            "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -2168,9 +2166,9 @@
             "dev": true
         },
         "node_modules/deepmerge": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-            "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2212,17 +2210,17 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.0.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-            "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.284",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "version": "1.4.339",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.339.tgz",
+            "integrity": "sha512-MSXHBJGcbBydq/DQDlpBeUKnJ6C7aTiNCTRpfDV5Iz0sNr/Ng6RJFloq82AAicp/SrmDq4zF6XsKG0B8Xwn1UQ==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -2282,11 +2280,12 @@
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
             "engines": {
-                "node": ">=0.8.0"
+                "node": ">=8"
             }
         },
         "node_modules/eslint-scope": {
@@ -2586,9 +2585,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/has": {
@@ -2767,15 +2766,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/istanbul-lib-report": {
@@ -3282,6 +3272,39 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-snapshot/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jest-snapshot/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jest-snapshot/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
         "node_modules/jest-util": {
             "version": "29.5.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
@@ -3432,9 +3455,9 @@
             }
         },
         "node_modules/kafkajs": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.3.tgz",
-            "integrity": "sha512-JmzIiLHE/TdQ7b4I2B/DNMtfhTh66fmEaEg7gGkyQXBC6f1A7I2jSjeUsVIJfC8d9YcEIURyBjtOEKBO5OHVhg==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+            "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -3512,15 +3535,12 @@
             "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
+                "yallist": "^3.0.2"
             }
         },
         "node_modules/make-dir": {
@@ -3536,15 +3556,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/make-error": {
@@ -3673,15 +3684,15 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.7.tgz",
-            "integrity": "sha512-EJ3rzxL9pTWPjk5arA0s0dgXpnyiAbJDE6wHT62g7VsgrgQgmmZ+Ru++M1BFofncWja+Pnn3rEr3fieRySAdKQ==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
             "dev": true
         },
         "node_modules/node-sql-parser": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-4.6.1.tgz",
-            "integrity": "sha512-HR5d6h2hGdAct7KnrHe3W8AAFUfPzPpCEdVNfvTq0cH5PgW5yyL+WscFTJH2/Mrel80HMLJaifb2EwoRyctvJg==",
+            "version": "4.6.6",
+            "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-4.6.6.tgz",
+            "integrity": "sha512-zpash5xnRY6+0C9HFru32iRJV1LTkwtrVpO90i385tYVF6efyXK/B3Nsq/15Fuv2utxrqHNjKtL55OHb8sl+eQ==",
             "dependencies": {
                 "big-integer": "^1.6.48"
             },
@@ -3876,9 +3887,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -3967,9 +3978,9 @@
             }
         },
         "node_modules/pure-rand": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-            "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+            "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
             "dev": true,
             "funding": [
                 {
@@ -4054,9 +4065,9 @@
             }
         },
         "node_modules/resolve.exports": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.1.tgz",
-            "integrity": "sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+            "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -4137,18 +4148,12 @@
             "peer": true
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/serialize-javascript": {
@@ -4238,15 +4243,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/stack-utils/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/string-length": {
@@ -4351,9 +4347,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.16.5",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
-            "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
+            "version": "5.16.6",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
+            "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4370,17 +4366,17 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-            "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+            "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.14",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
-                "serialize-javascript": "^6.0.0",
-                "terser": "^5.14.1"
+                "serialize-javascript": "^6.0.1",
+                "terser": "^5.16.5"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -4537,6 +4533,39 @@
                 }
             }
         },
+        "node_modules/ts-jest/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-jest/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-jest/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
         "node_modules/ts-loader": {
             "version": "9.4.2",
             "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
@@ -4555,6 +4584,39 @@
                 "typescript": "*",
                 "webpack": "^5.0.0"
             }
+        },
+        "node_modules/ts-loader/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-loader/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-loader/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "node_modules/tslib": {
             "version": "1.14.1",
@@ -4651,6 +4713,15 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
+        },
+        "node_modules/tslint/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/tslint/node_modules/has-flag": {
             "version": "3.0.0",
@@ -4811,9 +4882,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.76.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
-            "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
+            "version": "5.76.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+            "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4929,9 +5000,9 @@
             }
         },
         "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "node_modules/yargs": {
@@ -5006,21 +5077,21 @@
             "dev": true
         },
         "@babel/core": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-            "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+            "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.21.0",
+                "@babel/generator": "^7.21.3",
                 "@babel/helper-compilation-targets": "^7.20.7",
-                "@babel/helper-module-transforms": "^7.21.0",
+                "@babel/helper-module-transforms": "^7.21.2",
                 "@babel/helpers": "^7.21.0",
-                "@babel/parser": "^7.21.0",
+                "@babel/parser": "^7.21.3",
                 "@babel/template": "^7.20.7",
-                "@babel/traverse": "^7.21.0",
-                "@babel/types": "^7.21.0",
+                "@babel/traverse": "^7.21.3",
+                "@babel/types": "^7.21.3",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -5033,22 +5104,16 @@
                     "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
                     "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
                     "dev": true
-                },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
                 }
             }
         },
         "@babel/generator": {
-            "version": "7.21.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-            "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+            "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.21.0",
+                "@babel/types": "^7.21.3",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -5078,29 +5143,6 @@
                 "browserslist": "^4.21.3",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-environment-visitor": {
@@ -5252,6 +5294,12 @@
                     "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
                     "dev": true
                 },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+                    "dev": true
+                },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5270,9 +5318,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-            "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+            "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -5413,27 +5461,27 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-            "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+            "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.21.1",
+                "@babel/generator": "^7.21.3",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.21.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.21.2",
-                "@babel/types": "^7.21.2",
+                "@babel/parser": "^7.21.3",
+                "@babel/types": "^7.21.3",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-            "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+            "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -5885,9 +5933,9 @@
             }
         },
         "@types/eslint": {
-            "version": "8.21.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
-            "integrity": "sha512-rc9K8ZpVjNcLs8Fp0dkozd5Pt2Apk1glO4Vgz8ix1u6yFByxfqo5Yavpy65o+93TAe24jr7v+eSBtFLvOQtCRQ==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+            "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
             "dev": true,
             "peer": true,
             "requires": {
@@ -5947,9 +5995,9 @@
             }
         },
         "@types/jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
-            "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+            "version": "29.5.0",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+            "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
             "dev": true,
             "requires": {
                 "expect": "^29.0.0",
@@ -5969,9 +6017,9 @@
             "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
         },
         "@types/node": {
-            "version": "18.14.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-            "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
+            "version": "18.15.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.7.tgz",
+            "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA=="
         },
         "@types/prettier": {
             "version": "2.7.2",
@@ -5986,9 +6034,9 @@
             "dev": true
         },
         "@types/yargs": {
-            "version": "17.0.17",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-            "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.23.tgz",
+            "integrity": "sha512-yuogunc04OnzGQCrfHx+Kk883Q4X0aSwmYZhKjI21m+SVYzjIbrWl8dOOwSv5hf2Um2pdCOXWo9isteZTNXUZQ==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -6377,15 +6425,15 @@
             }
         },
         "browserslist": {
-            "version": "4.21.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-            "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+            "version": "4.21.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001400",
-                "electron-to-chromium": "^1.4.251",
-                "node-releases": "^2.0.6",
-                "update-browserslist-db": "^1.0.9"
+                "caniuse-lite": "^1.0.30001449",
+                "electron-to-chromium": "^1.4.284",
+                "node-releases": "^2.0.8",
+                "update-browserslist-db": "^1.0.10"
             }
         },
         "bs-logger": {
@@ -6431,9 +6479,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001439",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-            "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+            "version": "1.0.30001469",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+            "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
             "dev": true
         },
         "chalk": {
@@ -6459,9 +6507,9 @@
             "peer": true
         },
         "ci-info": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
-            "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+            "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
             "dev": true
         },
         "cjs-module-lexer": {
@@ -6514,6 +6562,11 @@
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
                     "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
                 },
                 "has-flag": {
                     "version": "3.0.0",
@@ -6607,6 +6660,11 @@
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
                     "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
                 },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+                },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6667,9 +6725,9 @@
             }
         },
         "commander": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-            "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -6715,9 +6773,9 @@
             "dev": true
         },
         "deepmerge": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-            "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true
         },
         "delayed-stream": {
@@ -6744,14 +6802,14 @@
             "dev": true
         },
         "dotenv": {
-            "version": "16.0.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-            "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
         },
         "electron-to-chromium": {
-            "version": "1.4.284",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "version": "1.4.339",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.339.tgz",
+            "integrity": "sha512-MSXHBJGcbBydq/DQDlpBeUKnJ6C7aTiNCTRpfDV5Iz0sNr/Ng6RJFloq82AAicp/SrmDq4zF6XsKG0B8Xwn1UQ==",
             "dev": true
         },
         "emittery": {
@@ -6799,9 +6857,10 @@
             "dev": true
         },
         "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -7014,9 +7073,9 @@
             "dev": true
         },
         "graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "has": {
@@ -7144,14 +7203,6 @@
                 "@istanbuljs/schema": "^0.1.2",
                 "istanbul-lib-coverage": "^3.2.0",
                 "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
             }
         },
         "istanbul-lib-report": {
@@ -7538,6 +7589,32 @@
                 "natural-compare": "^1.4.0",
                 "pretty-format": "^29.5.0",
                 "semver": "^7.3.5"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
             }
         },
         "jest-util": {
@@ -7655,9 +7732,9 @@
             "dev": true
         },
         "kafkajs": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.3.tgz",
-            "integrity": "sha512-JmzIiLHE/TdQ7b4I2B/DNMtfhTh66fmEaEg7gGkyQXBC6f1A7I2jSjeUsVIJfC8d9YcEIURyBjtOEKBO5OHVhg=="
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+            "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA=="
         },
         "kleur": {
             "version": "3.0.3",
@@ -7714,12 +7791,12 @@
             "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "requires": {
-                "yallist": "^4.0.0"
+                "yallist": "^3.0.2"
             }
         },
         "make-dir": {
@@ -7729,14 +7806,6 @@
             "dev": true,
             "requires": {
                 "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
             }
         },
         "make-error": {
@@ -7844,15 +7913,15 @@
             "dev": true
         },
         "node-releases": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.7.tgz",
-            "integrity": "sha512-EJ3rzxL9pTWPjk5arA0s0dgXpnyiAbJDE6wHT62g7VsgrgQgmmZ+Ru++M1BFofncWja+Pnn3rEr3fieRySAdKQ==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
             "dev": true
         },
         "node-sql-parser": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-4.6.1.tgz",
-            "integrity": "sha512-HR5d6h2hGdAct7KnrHe3W8AAFUfPzPpCEdVNfvTq0cH5PgW5yyL+WscFTJH2/Mrel80HMLJaifb2EwoRyctvJg==",
+            "version": "4.6.6",
+            "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-4.6.6.tgz",
+            "integrity": "sha512-zpash5xnRY6+0C9HFru32iRJV1LTkwtrVpO90i385tYVF6efyXK/B3Nsq/15Fuv2utxrqHNjKtL55OHb8sl+eQ==",
             "requires": {
                 "big-integer": "^1.6.48"
             }
@@ -7989,9 +8058,9 @@
             }
         },
         "prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw=="
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw=="
         },
         "pretty-format": {
             "version": "29.5.0",
@@ -8053,9 +8122,9 @@
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         },
         "pure-rand": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-            "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+            "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
             "dev": true
         },
         "randombytes": {
@@ -8112,9 +8181,9 @@
             "dev": true
         },
         "resolve.exports": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.1.tgz",
-            "integrity": "sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+            "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
             "dev": true
         },
         "safe-buffer": {
@@ -8167,13 +8236,10 @@
             }
         },
         "semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
         },
         "serialize-javascript": {
             "version": "6.0.1",
@@ -8247,14 +8313,6 @@
             "dev": true,
             "requires": {
                 "escape-string-regexp": "^2.0.0"
-            },
-            "dependencies": {
-                "escape-string-regexp": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-                    "dev": true
-                }
             }
         },
         "string-length": {
@@ -8326,9 +8384,9 @@
             "dev": true
         },
         "terser": {
-            "version": "5.16.5",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
-            "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
+            "version": "5.16.6",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
+            "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
             "dev": true,
             "peer": true,
             "requires": {
@@ -8359,17 +8417,17 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-            "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+            "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
             "dev": true,
             "peer": true,
             "requires": {
-                "@jridgewell/trace-mapping": "^0.3.14",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
-                "serialize-javascript": "^6.0.0",
-                "terser": "^5.14.1"
+                "serialize-javascript": "^6.0.1",
+                "terser": "^5.16.5"
             },
             "dependencies": {
                 "jest-worker": {
@@ -8442,6 +8500,32 @@
                 "make-error": "1.x",
                 "semver": "7.x",
                 "yargs-parser": "^21.0.1"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
             }
         },
         "ts-loader": {
@@ -8454,6 +8538,32 @@
                 "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
                 "semver": "^7.3.4"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
             }
         },
         "tslib": {
@@ -8522,6 +8632,12 @@
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
                     "dev": true
                 },
                 "has-flag": {
@@ -8643,9 +8759,9 @@
             }
         },
         "webpack": {
-            "version": "5.76.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
-            "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
+            "version": "5.76.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+            "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
             "dev": true,
             "peer": true,
             "requires": {
@@ -8725,9 +8841,9 @@
             "dev": true
         },
         "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "yargs": {

--- a/src/kafka/cleanKafka.ts
+++ b/src/kafka/cleanKafka.ts
@@ -25,6 +25,7 @@ async function deleteSchemaSubjects(topics: any): Promise<void> {
             .catch((error) => {
                 console.error(error.response.status);
                 console.error(error.response.data.message);
+                process.exit(1);
             });
     }
 }

--- a/tests/datagen.test.ts
+++ b/tests/datagen.test.ts
@@ -39,8 +39,12 @@ describe('Schema Parsing Tests', () => {
 describe('Test missing schema file', () => {
     test('should return error if schema file does not exist', () => {
         const schema = './tests/schema1.avro';
-        const output = datagen(`-s ${schema} -n 2`);
-        expect(output).toContain(`Schema file ${schema} does not exist!`);
+        try {
+            const output = datagen(`-s ${schema} -n 2`);
+        } catch (error) {
+            expect(error.stdout.toString()).toContain(`Schema file ${schema} does not exist!`);
+            expect(error.status).toBe(1);
+        }
     });
 });
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Switching the Kafka + CSR + Zookeeper containers to Redpanda.
Adding a path ignore for the `.md`, `.txt` files, and `examples` directory.

Not 100% sure if there will be any actual benefits of switching to the image caching suggestion as we only have the Redpanda image that will be pulled and we need to make sure that the datagen image is built fresh on every run to prevent some weird results. Open to suggestions!

## Related Tickets & Documents

Closes #87 

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
