### PR TITLE
bump faker version

### DIFF
--- a/datagen.ts
+++ b/datagen.ts
@@ -17,7 +17,7 @@ import dataGenerator from './src/dataGenerator.js';
 import fs from 'fs';
 import { program, Option } from 'commander';
 
-program.name('datagen').description('Fake Data Generator').version('0.5.0');
+program.name('datagen').description('Fake Data Generator').version('0.5.1');
 
 program
     .requiredOption('-s, --schema <char>', 'Schema file to use')

--- a/datagen.ts
+++ b/datagen.ts
@@ -17,7 +17,7 @@ import dataGenerator from './src/dataGenerator.js';
 import fs from 'fs';
 import { program, Option } from 'commander';
 
-program.name('datagen').description('Fake Data Generator').version('0.5.1');
+program.name('datagen').description('Fake Data Generator').version('0.6.0');
 
 program
     .requiredOption('-s, --schema <char>', 'Schema file to use')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@materializeinc/datagen",
     "description": "Materialize Datagen CLI tool",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "license": "Apache-2.0",
     "type": "module",
     "bin": {
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@avro/types": "^1.0.25",
-        "@faker-js/faker": "^7.6.0",
+        "@faker-js/faker": "^8.4.1",
         "@kafkajs/confluent-schema-registry": "^3.3.0",
         "@types/node": "^18.14.6",
         "arg": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@materializeinc/datagen",
     "description": "Materialize Datagen CLI tool",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "license": "Apache-2.0",
     "type": "module",
     "bin": {


### PR DESCRIPTION
Bump [faker](https://fakerjs.dev/api/) to the latest version, 8.4.1.
